### PR TITLE
Add a bit of documentation for virtual environments

### DIFF
--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -44,8 +44,7 @@
             "MYPY_PATH": "$sublime_py_files_dir:$packages"
         },
         // --- JEDI configuration ---------------------------------------------
-        // In vase you are using a virtual environment, specify a path to it for the
-        // server to run within the correct environment.
+        // If you are using a virtual environment, specify a path to it to here.
         // "pylsp.plugins.jedi.environment": "./.venv/myproject",
         "pylsp.plugins.jedi.extra_paths": [
             "$sublime_py_files_dir",

--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -44,6 +44,9 @@
             "MYPY_PATH": "$sublime_py_files_dir:$packages"
         },
         // --- JEDI configuration ---------------------------------------------
+        // In vase you are using a virtual environment, specify a path to it for the
+        // server to run within the correct environment.
+        // "pylsp.plugins.jedi.environment": "./.venv/myproject",
         "pylsp.plugins.jedi.extra_paths": [
             "$sublime_py_files_dir",
             "$packages"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To use this package, you must have:
 - An executable `python` (on Windows) or `python3` (on Linux/macOS)
 - The [LSP](https://packagecontrol.io/packages/LSP) package
 - For Ubuntu and Debian users, you must also install `python3-venv` with `apt`
+- It's recommended to also install the `LSP-json` package which will provide autocompletion and validation for this package's settings.
 
 ## Applicable Selectors
 
@@ -26,6 +27,20 @@ case, that means that when you open a view with the `source.python` base scope, 
 ## Configuration
 
 Configure the Python LSP Server by accessing `Preferences > Package Settings > LSP > Servers > LSP-pylsp`.
+
+### Virtual environments
+
+If your project needs to run and be validated within a virtual environment, point to it using the `pylsp.plugins.jedi.environment` settings. For example if your virtual environment lives in `.venv/myproject` within the the project directory then set it like so:
+
+```json
+{
+    "settings": {
+        "pylsp.plugins.jedi.environment": "./.venv/myproject",
+    }
+}
+```
+
+You can set it in `LSP-pylsp` global settings or (more likely) override it per project.
 
 ## Code Completion
 


### PR DESCRIPTION
This seems to work for me for completions and stuff but this doesn't apply for plugins. Or at least it doesn't apply for `mypy-ls` plugin so that one still reports imports being missing. I think it's a limitation of the server.