### PR TITLE
Rename MYPY_PATH env to MYPYPATH

### DIFF
--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -35,14 +35,12 @@
     ],
     "env": {
         "PYTHONPATH": "$sublime_py_files_dir:$packages",
-        "MYPY_PATH": "$sublime_py_files_dir:$packages"
+        // Override MYPYPATH to extend the paths that mypy searches when looking for stub files.
+        // Alternatively create a mypy.ini configuration file at the root of the project with `mypy_path` option set.
+        // See https://mypy.readthedocs.io/en/stable/config_file.html?highlight=mypy_path#confval-mypy_path
+        "MYPYPATH": "$sublime_py_files_dir:$packages"
     },
     "settings": {
-        // --- env ------------------------------------------------------------
-        "pylsp.env": {
-            "PYTHONPATH": "$sublime_py_files_dir:$packages",
-            "MYPY_PATH": "$sublime_py_files_dir:$packages"
-        },
         // --- JEDI configuration ---------------------------------------------
         // If you are using a virtual environment, specify a path to it to here.
         // "pylsp.plugins.jedi.environment": "./.venv/myproject",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -12,13 +12,6 @@
               "properties": {
                 "settings": {
                   "properties": {
-                    "pylsp.env": {
-                      "description": "Overrides for server environment variables.",
-                      "type": "object",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
                     "pylsp.executable": {
                       "type": "string",
                       "default": "pylsp",


### PR DESCRIPTION
According to my testing mypy doesn't pick up MYPY_PATH. MYPYPATH works.

Also removed the "pylsp.env" setting as I couldn't find any reference to
it in either the main python server or any third party plugin (searched
for just whole-word `env`).