### PR TITLE
Expand documentation for virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ Configure the Python LSP Server by accessing `Preferences > Package Settings > L
 
 ### Virtual environments
 
-If your project needs to run and be validated within a virtual environment, point to it using the `pylsp.plugins.jedi.environment` settings. For example if your virtual environment lives in `.venv/myproject` within the the project directory then set it like so:
+If your project needs to run and be validated within a virtual environment, point to the environment using the `pylsp.plugins.jedi.environment` setting. For example if your virtual environment lives in `.venv/myproject` within the the project directory then run `Project: Edit Project` from the Command Palette and add the setting like so:
 
 ```json
 {
+    // "folders": [
+    //     ...
+    // ]
     "settings":
     {
         "LSP":
@@ -50,7 +53,7 @@ If your project needs to run and be validated within a virtual environment, poin
 }
 ```
 
-You can set it in `LSP-pylsp` global settings or (more likely) override it per project.
+You can also set it in the `LSP-pylsp` global settings but it's more likely that you'd want this to be overriden per-project.
 
 ## Code Completion
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,18 @@ If your project needs to run and be validated within a virtual environment, poin
 
 ```json
 {
-    "settings": {
-        "pylsp.plugins.jedi.environment": "./.venv/myproject",
+    "settings":
+    {
+        "LSP":
+        {
+            "LSP-pylsp":
+            {
+                "settings":
+                {
+                    "pylsp.plugins.jedi.environment": "./.venv/myproject"
+                }
+            }
+        }
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configure the Python LSP Server by accessing `Preferences > Package Settings > L
 
 If your project needs to run and be validated within a virtual environment, point to the environment using the `pylsp.plugins.jedi.environment` setting. For example if your virtual environment lives in `.venv/myproject` within the the project directory then run `Project: Edit Project` from the Command Palette and add the setting like so:
 
-```json
+```jsonc
 {
     // "folders": [
     //     ...


### PR DESCRIPTION
I was able to configure virtual env in project only with this [issue](https://github.com/sublimelsp/LSP-pylsp/issues/31), thanks to the question. As for me there's kind of unintuitive project settings structure, so i add it to the man page explicitly.