### PR TITLE
Update and rename the mypy-ls plugin (new name pylsp-mypy)

### DIFF
--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -67,10 +67,10 @@
         "pylsp.plugins.pyflakes.enabled": false,
         "pylsp.plugins.pylint.enabled": false,
         "pylsp.plugins.flake8.enabled": false,
-        "pylsp.plugins.mypy_ls.enabled": false,
-        "pylsp.plugins.mypy-ls.dmypy": false,
-        "pylsp.plugins.mypy-ls.live_mode": true,
-        "pylsp.plugins.mypy-ls.strict": false,
+        "pylsp.plugins.pylsp_mypy.enabled": false,
+        "pylsp.plugins.pylsp_mypy.dmypy": false,
+        "pylsp.plugins.pylsp_mypy.live_mode": true,
+        "pylsp.plugins.pylsp_mypy.strict": false,
         // --- Formatters -----------------------------------------------------
         // By default, autopep8 is enabled
         "pylsp.plugins.autopep8.enabled": true,

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The default linter is `pycodestyle`. The possible linters are:
   `["pycodestyle"]`.
 - pyflakes (`"pylsp.plugins.pyflakes.enabled"` in the settings)
 - pylint (`"pylsp.plugins.pylint.enabled"` in the settings)
-- mypy_ls (`"pylsp.plugins.mypy_ls.enabled"` in the settings)
+- pylsp_mypy (`"pylsp.plugins.pylsp_mypy.enabled"` in the settings)
 
 After changing a linter, you must restart Sublime Text.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-lsp-server[all]==1.1.0
 python-lsp-black==1.0.0
 pyls_isort==0.2.2
-mypy-ls==0.4.1
+pylsp-mypy==0.5.1

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -349,22 +349,22 @@
                       "default": false,
                       "description": "Enable or disable the plugin."
                     },
-                    "pylsp.plugins.mypy_ls.enabled": {
+                    "pylsp.plugins.pylsp_mypy.enabled": {
                       "type": "boolean",
                       "default": false,
                       "description": "Enable or disable the plugin."
                     },
-                    "pylsp.plugins.mypy-ls.dmypy": {
+                    "pylsp.plugins.pylsp_mypy.dmypy": {
                       "type": "boolean",
                       "default": false,
                       "markdownDescription": "Execute via `dmypy run` rather than `mypy`. This uses the `dmypy` daemon and may dramatically improve the responsiveness of the `pylsp` server, however this currently does not work in `live_mode`. Enabling this disables `live_mode`, even for conflicting configs."
                     },
-                    "pylsp.plugins.mypy-ls.live_mode": {
+                    "pylsp.plugins.pylsp_mypy.live_mode": {
                       "type": "boolean",
                       "default": true,
                       "markdownDescription": "Provide type checking as you type. This writes to a tempfile every time a check is done. Turning off `live_mode` means you must save your changes for mypy diagnostics to update correctly."
                     },
-                    "pylsp.plugins.mypy-ls.strict": {
+                    "pylsp.plugins.pylsp_mypy.strict": {
                       "type": "boolean",
                       "default": false,
                       "markdownDescription": "Refers to the `strict` option of `mypy`. This option often is too strict to be useful."


### PR DESCRIPTION
Supersedes #40

This updates mypy-ls 0.4.1 to pylsp-mypy 0.5.1 (the package was renamed). It also updates the information in README as well as the JSON schema and sublime settings file to use the new configuration namespace - `pylsp.plugings.pylsp_mypy`. Usage of the old configuration namespace causes the plugin to crash due to DeprecationWarning being raised (see: https://github.com/Richardk2n/pylsp-mypy/issues/15).