### PR TITLE
chore: bump python-lsp-server[all] from 1.1.0 to 1.2.0

### DIFF
--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -42,14 +42,14 @@
     },
     "settings": {
         // --- JEDI configuration ---------------------------------------------
-        // Define environment variables for jedi.Script and Jedi.names.
-        "pylsp.plugins.jedi.env_vars": {},
-        // Define environment for jedi.Script and Jedi.names.
-        "pylsp.plugins.jedi.environment": null,
         // Additional paths to extend the JEDI engine with.
         // If you are using a virtual environment, specify a path to it to here.
         // "pylsp.plugins.jedi.environment": "./.venv/myproject",
         "pylsp.plugins.jedi.extra_paths": ["$sublime_py_files_dir", "$packages"],
+        // Define environment variables for jedi.Script and Jedi.names.
+        "pylsp.plugins.jedi.env_vars": {},
+        // Define environment for jedi.Script and Jedi.names.
+        "pylsp.plugins.jedi.environment": null,
         // Enable or disable the plugin.
         "pylsp.plugins.jedi_completion.enabled": true,
         // Modules for which the labels should be cached.

--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -42,14 +42,52 @@
     },
     "settings": {
         // --- JEDI configuration ---------------------------------------------
+        // Define environment variables for jedi.Script and Jedi.names.
+        "pylsp.plugins.jedi.env_vars": {},
+        // Define environment for jedi.Script and Jedi.names.
+        "pylsp.plugins.jedi.environment": null,
+        // Additional paths to extend the JEDI engine with.
         // If you are using a virtual environment, specify a path to it to here.
         // "pylsp.plugins.jedi.environment": "./.venv/myproject",
-        "pylsp.plugins.jedi.extra_paths": [
-            "$sublime_py_files_dir",
-            "$packages"
-        ],
+        "pylsp.plugins.jedi.extra_paths": ["$sublime_py_files_dir", "$packages"],
+        // Enable or disable the plugin.
         "pylsp.plugins.jedi_completion.enabled": true,
+        // Modules for which the labels should be cached.
+        "pylsp.plugins.jedi_completion.cache_labels_for": ["pandas", "numpy", "tensorflow", "matplotlib"],
+        // Resolve documentation and detail eagerly.
+        "pylsp.plugins.jedi_completion.eager": false,
+        // Enable fuzzy when requesting autocomplete.
         "pylsp.plugins.jedi_completion.fuzzy": true,
+        // Adds class objects as a separate completion item.
+        "pylsp.plugins.jedi_completion.include_class_objects": true,
+        // Auto-completes methods and classes with tabstops for each parameter.
+        "pylsp.plugins.jedi_completion.include_params": true,
+        // How many labels (at most) should be resolved?
+        "pylsp.plugins.jedi_completion.resolve_at_most_labels": 25,
+        // Enable or disable the plugin.
+        "pylsp.plugins.jedi_definition.enabled": true,
+        // If follow_imports is True will decide if it follow builtin imports.
+        "pylsp.plugins.jedi_definition.follow_builtin_imports": true,
+        // The goto call will follow imports.
+        "pylsp.plugins.jedi_definition.follow_imports": true,
+        // Enable or disable the plugin.
+        "pylsp.plugins.jedi_hover.enabled": true,
+        // Enable or disable the plugin.
+        "pylsp.plugins.jedi_references.enabled": true,
+        // Enable or disable the plugin.
+        "pylsp.plugins.jedi_signature_help.enabled": true,
+        // If True lists the names of all scopes instead of only the module namespace.
+        "pylsp.plugins.jedi_symbols.all_scopes": true,
+        // Enable or disable the plugin.
+        "pylsp.plugins.jedi_symbols.enabled": true,
+        // If True includes symbols imported from other libraries.
+        "pylsp.plugins.jedi_symbols.include_import_symbols": true,
+        // Builtin and c-extension modules that are allowed to be imported and inspected by rope.
+        "pylsp.rope.extensionModules": null,
+        // The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such
+        // a folder at all.
+        "pylsp.rope.ropeFolder": null,
+
         // --- Linters --------------------------------------------------------
         // Configuration is computed first from user configuration (in home directory),
         // overridden by configuration passed in by the language client,
@@ -66,11 +104,88 @@
         "pylsp.plugins.pydocstyle.enabled": false,
         "pylsp.plugins.pyflakes.enabled": false,
         "pylsp.plugins.pylint.enabled": false,
-        "pylsp.plugins.flake8.enabled": false,
         "pylsp.plugins.pylsp_mypy.enabled": false,
+        "pylsp.plugins.flake8.enabled": false,
+        // Path to the config file that will be the authoritative config source.
+        "pylsp.plugins.flake8.config": null,
+        // Exclude files or directories which match these patterns.
+        "pylsp.plugins.flake8.exclude": null,
+        // Path to the flake8 executable.
+        "pylsp.plugins.flake8.executable": "flake8",
+        // When parsing directories, only check filenames matching these patterns.
+        "pylsp.plugins.flake8.filename": null,
+        // Hang closing bracket instead of matching indentation of opening bracket's line.
+        "pylsp.plugins.flake8.hangClosing": null,
+        // Ignore errors and warnings.
+        "pylsp.plugins.flake8.ignore": null,
+        // Set maximum allowed line length.
+        "pylsp.plugins.flake8.maxLineLength": null,
+        // Ignore errors and warnings per file.
+        // Each individual item should be in a format `file_path:error_code`. For example `"project/__init__.py:W305,W304"`.
+        "pylsp.plugins.flake8.perFileIgnores": null,
+        // Select errors and warnings.
+        "pylsp.plugins.flake8.select": null,
+        // Enable or disable the plugin.
+        "pylsp.plugins.mccabe.enabled": true,
+        // The minimum threshold that triggers warnings about cyclomatic complexity.
+        "pylsp.plugins.mccabe.threshold": 15,
+        // Enable or disable the plugin.
+        "pylsp.plugins.preload.enabled": true,
+        // List of modules to import on startup
+        "pylsp.plugins.preload.modules": null,
+        // Enable non-whitespace auto-fixes. Higher number results in more aggressive changes. For example, `E712`
+        // requires aggressiveness level 2 (since `x == True` could be changed to either `x` or `x is True`, but
+        // `autopep8` chooses the former). will also shorten lines more aggressively. Will also shorten the lines and
+        // remove trailing whitespace more aggressively.
+        "pylsp.plugins.pycodestyle.aggressive": null,
+        // Exclude files or directories which match these patterns.
+        "pylsp.plugins.pycodestyle.exclude": null,
+        // When parsing directories, only check filenames matching these patterns.
+        "pylsp.plugins.pycodestyle.filename": null,
+        // Hang closing bracket instead of matching indentation of opening bracket's line.
+        "pylsp.plugins.pycodestyle.hangClosing": null,
+        // Ignore errors and warnings.
+        "pylsp.plugins.pycodestyle.ignore": null,
+        // Set maximum allowed line length.
+        "pylsp.plugins.pycodestyle.maxLineLength": null,
+        // Select errors and warnings.
+        "pylsp.plugins.pycodestyle.select": null,
+        // Ignore errors and warnings in addition to the specified convention.
+        "pylsp.plugins.pydocstyle.addIgnore": null,
+        // Select errors and warnings in addition to the specified convention.
+        "pylsp.plugins.pydocstyle.addSelect": null,
+        // Choose the basic list of checked errors by specifying an existing convention.
+        // possible values: pep257, numpy
+        "pylsp.plugins.pydocstyle.convention": null,
+        // Ignore errors and warnings.
+        "pylsp.plugins.pydocstyle.ignore": null,
+        // Check only files that exactly match the given regular expression; default is to match files that don't start
+        // with 'test_' but end with '.py'.
+        "pylsp.plugins.pydocstyle.match": "(?!test_).*\\.py",
+        // Search only dirs that exactly match the given regular expression; default is to match dirs which do not begin
+        // with a dot.
+        "pylsp.plugins.pydocstyle.matchDir": "[^\\.].*",
+        // Select errors and warnings.
+        "pylsp.plugins.pydocstyle.select": null,
+        // Arguments to pass to pylint.
+        "pylsp.plugins.pylint.args": null,
+        // Executable to run pylint with. Setting this will run pylint on unsaved files via stdin. Can slow down
+        // workflow. Only works with python3.
+        "pylsp.plugins.pylint.executable": "",
+        // Execute via `dmypy run` rather than `mypy`. This uses the `dmypy` daemon and may dramatically improve the
+        // responsiveness of the `pylsp` server, however this currently does not work in `live_mode`. Enabling this
+        // disables `live_mode`, even for conflicting configs.
         "pylsp.plugins.pylsp_mypy.dmypy": false,
+        // Provide type checking as you type. This writes to a tempfile every time a check is done. Turning off
+        // `live_mode` means you must save your changes for mypy diagnostics to update correctly.
         "pylsp.plugins.pylsp_mypy.live_mode": true,
+        // Refers to the `strict` option of `mypy`. This option often is too strict to be useful.
         "pylsp.plugins.pylsp_mypy.strict": false,
+        // Resolve documentation and detail eagerly.
+        "pylsp.plugins.rope_completion.eager": false,
+        // Enable or disable the plugin.
+        "pylsp.plugins.rope_completion.enabled": true,
+
         // --- Formatters -----------------------------------------------------
         // By default, autopep8 is enabled
         "pylsp.plugins.autopep8.enabled": true,

--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -98,14 +98,15 @@
         // change "pylsp.configurationSources" to ["flake8"], and you must
         // enable the flake8 plugin (see below), and you must disable the
         // pycodestyle plugin (see below).
-        "pylsp.configurationSources": ["pycodestyle"],
         // By default, pycodestyle is enabled
+        "pylsp.configurationSources": ["pycodestyle"],
+        "pylsp.plugins.flake8.enabled": false,
         "pylsp.plugins.pycodestyle.enabled": true,
         "pylsp.plugins.pydocstyle.enabled": false,
         "pylsp.plugins.pyflakes.enabled": false,
         "pylsp.plugins.pylint.enabled": false,
         "pylsp.plugins.pylsp_mypy.enabled": false,
-        "pylsp.plugins.flake8.enabled": false,
+        // --- flake8 settings ---
         // Path to the config file that will be the authoritative config source.
         "pylsp.plugins.flake8.config": null,
         // Exclude files or directories which match these patterns.
@@ -125,14 +126,17 @@
         "pylsp.plugins.flake8.perFileIgnores": null,
         // Select errors and warnings.
         "pylsp.plugins.flake8.select": null,
+        // --- mccabe settings ---
         // Enable or disable the plugin.
         "pylsp.plugins.mccabe.enabled": true,
         // The minimum threshold that triggers warnings about cyclomatic complexity.
         "pylsp.plugins.mccabe.threshold": 15,
+        // --- preload settings ---
         // Enable or disable the plugin.
         "pylsp.plugins.preload.enabled": true,
         // List of modules to import on startup
         "pylsp.plugins.preload.modules": null,
+        // --- pycodestyle settings ---
         // Enable non-whitespace auto-fixes. Higher number results in more aggressive changes. For example, `E712`
         // requires aggressiveness level 2 (since `x == True` could be changed to either `x` or `x is True`, but
         // `autopep8` chooses the former). will also shorten lines more aggressively. Will also shorten the lines and
@@ -150,6 +154,7 @@
         "pylsp.plugins.pycodestyle.maxLineLength": null,
         // Select errors and warnings.
         "pylsp.plugins.pycodestyle.select": null,
+        // --- pydocstyle settings ---
         // Ignore errors and warnings in addition to the specified convention.
         "pylsp.plugins.pydocstyle.addIgnore": null,
         // Select errors and warnings in addition to the specified convention.
@@ -167,11 +172,13 @@
         "pylsp.plugins.pydocstyle.matchDir": "[^\\.].*",
         // Select errors and warnings.
         "pylsp.plugins.pydocstyle.select": null,
+        // --- pylint settings ---
         // Arguments to pass to pylint.
         "pylsp.plugins.pylint.args": null,
         // Executable to run pylint with. Setting this will run pylint on unsaved files via stdin. Can slow down
         // workflow. Only works with python3.
         "pylsp.plugins.pylint.executable": "",
+        // --- pylsp_mypy settings ---
         // Execute via `dmypy run` rather than `mypy`. This uses the `dmypy` daemon and may dramatically improve the
         // responsiveness of the `pylsp` server, however this currently does not work in `live_mode`. Enabling this
         // disables `live_mode`, even for conflicting configs.
@@ -181,6 +188,7 @@
         "pylsp.plugins.pylsp_mypy.live_mode": true,
         // Refers to the `strict` option of `mypy`. This option often is too strict to be useful.
         "pylsp.plugins.pylsp_mypy.strict": false,
+        // --- rope_completion settings ---
         // Resolve documentation and detail eagerly.
         "pylsp.plugins.rope_completion.eager": false,
         // Enable or disable the plugin.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-lsp-server[all]==1.1.0
+python-lsp-server[all]==1.2.0
 python-lsp-black==1.0.0
 pyls-isort==0.2.2
 pylsp-mypy==0.5.1

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -95,7 +95,17 @@
                         "type": "string"
                       },
                       "uniqueItems": true,
-                      "markdownDescription": "Ignore errors and warnings per file.\n\nEach individual item should be in a format `file_path:error_code`. For example `\"project/__init__.py:F401\"`."
+                      "markdownDescription": "Ignore errors and warnings per file.\n\nEach individual item should be in a format `file_path:error_code`. For example `\"project/__init__.py:W305,W304\"`."
+                    },
+                    "pylsp.plugins.flake8.config": {
+                      "type": "string",
+                      "default": null,
+                      "description": "Path to the config file that will be the authoritative config source."
+                    },
+                    "pylsp.plugins.flake8.executable": {
+                      "type": "string",
+                      "default": "flake8",
+                      "description": "Path to the flake8 executable."
                     },
                     "pylsp.plugins.jedi.extra_paths": {
                       "description": "Additional paths to extend the JEDI engine with.",
@@ -136,6 +146,24 @@
                       "default": true,
                       "description": "Enable fuzzy when requesting autocomplete."
                     },
+                    "pylsp.plugins.jedi_completion.eager": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Resolve documentation and detail eagerly."
+                    },
+                    "pylsp.plugins.jedi_completion.resolve_at_most_labels": {
+                      "type": "number",
+                      "default": 25,
+                      "description": "How many labels (at most) should be resolved?"
+                    },
+                    "pylsp.plugins.jedi_completion.cache_labels_for": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": ["pandas", "numpy", "tensorflow", "matplotlib"],
+                      "description": "Modules for which the labels should be cached."
+                    },
                     "pylsp.plugins.jedi_definition.enabled": {
                       "type": "boolean",
                       "default": true,
@@ -175,6 +203,11 @@
                       "type": "boolean",
                       "default": true,
                       "description": "If True lists the names of all scopes instead of only the module namespace."
+                    },
+                    "pylsp.plugins.jedi_symbols.include_import_symbols": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "If True includes symbols imported from other libraries."
                     },
                     "pylsp.plugins.mccabe.enabled": {
                       "type": "boolean",
@@ -373,6 +406,11 @@
                       "type": "boolean",
                       "default": true,
                       "description": "Enable or disable the plugin."
+                    },
+                    "pylsp.plugins.rope_completion.eager": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Resolve documentation and detail eagerly."
                     },
                     "pylsp.plugins.yapf.enabled": {
                       "type": "boolean",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -43,7 +43,10 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.plugins.flake8.exclude": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -52,7 +55,10 @@
                       "description": "Exclude files or directories which match these patterns."
                     },
                     "pylsp.plugins.flake8.filename": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -61,12 +67,18 @@
                       "description": "When parsing directories, only check filenames matching these patterns."
                     },
                     "pylsp.plugins.flake8.hangClosing": {
-                      "type": "boolean",
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
                     },
                     "pylsp.plugins.flake8.ignore": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -75,12 +87,18 @@
                       "description": "Ignore errors and warnings."
                     },
                     "pylsp.plugins.flake8.maxLineLength": {
-                      "type": "number",
+                      "type": [
+                        "number",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Set maximum allowed line length."
                     },
                     "pylsp.plugins.flake8.select": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -89,7 +107,10 @@
                       "description": "Select errors and warnings."
                     },
                     "pylsp.plugins.flake8.perFileIgnores": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -98,7 +119,10 @@
                       "markdownDescription": "Ignore errors and warnings per file.\n\nEach individual item should be in a format `file_path:error_code`. For example `\"project/__init__.py:W305,W304\"`."
                     },
                     "pylsp.plugins.flake8.config": {
-                      "type": "string",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Path to the config file that will be the authoritative config source."
                     },
@@ -122,7 +146,10 @@
                       "description": "Define environment variables for jedi.Script and Jedi.names."
                     },
                     "pylsp.plugins.jedi.environment": {
-                      "type": "string",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Define environment for jedi.Script and Jedi.names."
                     },
@@ -161,7 +188,12 @@
                       "items": {
                         "type": "string"
                       },
-                      "default": ["pandas", "numpy", "tensorflow", "matplotlib"],
+                      "default": [
+                        "pandas",
+                        "numpy",
+                        "tensorflow",
+                        "matplotlib"
+                      ],
                       "description": "Modules for which the labels should be cached."
                     },
                     "pylsp.plugins.jedi_definition.enabled": {
@@ -225,7 +257,10 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.plugins.preload.modules": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -239,7 +274,10 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.plugins.pycodestyle.exclude": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -248,7 +286,10 @@
                       "description": "Exclude files or directories which match these patterns."
                     },
                     "pylsp.plugins.pycodestyle.filename": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -257,7 +298,10 @@
                       "description": "When parsing directories, only check filenames matching these patterns."
                     },
                     "pylsp.plugins.pycodestyle.select": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -266,7 +310,10 @@
                       "description": "Select errors and warnings."
                     },
                     "pylsp.plugins.pycodestyle.ignore": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -275,17 +322,26 @@
                       "description": "Ignore errors and warnings."
                     },
                     "pylsp.plugins.pycodestyle.hangClosing": {
-                      "type": "boolean",
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
                     },
                     "pylsp.plugins.pycodestyle.maxLineLength": {
-                      "type": "number",
+                      "type": [
+                        "number",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Set maximum allowed line length."
                     },
                     "pylsp.plugins.pycodestyle.aggressive": {
-                      "type": "number",
+                      "type": [
+                        "number",
+                        "null"
+                      ],
                       "default": null,
                       "markdownDescription": "Enable non-whitespace auto-fixes. Higher number results in more aggressive changes. For example, `E712` requires aggressiveness level 2 (since `x == True` could be changed to either `x` or `x is True`, but `autopep8` chooses the former). will also shorten lines more aggressively. Will also shorten the lines and remove trailing whitespace more aggressively."
                     },
@@ -295,16 +351,23 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.plugins.pydocstyle.convention": {
-                      "type": "string",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
                       "default": null,
                       "enum": [
                         "pep257",
-                        "numpy"
+                        "numpy",
+                        null
                       ],
                       "description": "Choose the basic list of checked errors by specifying an existing convention."
                     },
                     "pylsp.plugins.pydocstyle.addIgnore": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -313,7 +376,10 @@
                       "description": "Ignore errors and warnings in addition to the specified convention."
                     },
                     "pylsp.plugins.pydocstyle.addSelect": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -322,7 +388,10 @@
                       "description": "Select errors and warnings in addition to the specified convention."
                     },
                     "pylsp.plugins.pydocstyle.ignore": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -331,7 +400,10 @@
                       "description": "Ignore errors and warnings."
                     },
                     "pylsp.plugins.pydocstyle.select": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -360,7 +432,10 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.plugins.pylint.args": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"
@@ -418,12 +493,18 @@
                       "description": "Enable or disable the plugin."
                     },
                     "pylsp.rope.extensionModules": {
-                      "type": "string",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
                       "default": null,
                       "description": "Builtin and c-extension modules that are allowed to be imported and inspected by rope."
                     },
                     "pylsp.rope.ropeFolder": {
-                      "type": "array",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "default": null,
                       "items": {
                         "type": "string"


### PR DESCRIPTION
Bumps [python-lsp-server[all]](https://github.com/python-lsp/python-lsp-server) from 1.1.0 to 1.2.0.
- [Release notes](https://github.com/python-lsp/python-lsp-server/releases)
- [Changelog](https://github.com/python-lsp/python-lsp-server/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/python-lsp/python-lsp-server/compare/v1.1.0...v1.2.0)

---
updated-dependencies:
- dependency-name: python-lsp-server[all]
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>