### PR TITLE
Don't pass empty object as "env_vars"

### DIFF
--- a/LSP-pylsp.sublime-settings
+++ b/LSP-pylsp.sublime-settings
@@ -43,13 +43,12 @@
     "settings": {
         // --- JEDI configuration ---------------------------------------------
         // Additional paths to extend the JEDI engine with.
-        // If you are using a virtual environment, specify a path to it to here.
-        // "pylsp.plugins.jedi.environment": "./.venv/myproject",
         "pylsp.plugins.jedi.extra_paths": ["$sublime_py_files_dir", "$packages"],
-        // Define environment variables for jedi.Script and Jedi.names.
-        "pylsp.plugins.jedi.env_vars": {},
         // Define environment for jedi.Script and Jedi.names.
+        // If you are using a virtual environment, specify a path to it to here. For example: "./.venv/myproject",
         "pylsp.plugins.jedi.environment": null,
+        // Define environment variables for jedi.Script and Jedi.names.
+        "pylsp.plugins.jedi.env_vars": null,
         // Enable or disable the plugin.
         "pylsp.plugins.jedi_completion.enabled": true,
         // Modules for which the labels should be cached.

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -139,8 +139,13 @@
                       }
                     },
                     "pylsp.plugins.jedi.env_vars": {
-                      "type": "object",
-                      "items": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "default": null,
+                      "minProperties": 1,
+                      "additionalProperties": {
                         "type": "string"
                       },
                       "description": "Define environment variables for jedi.Script and Jedi.names."


### PR DESCRIPTION
This causes crash when used in subprocess.Popen(..., env={}).

Fixes #49