### PR TITLE
Replace `pylsp_black` with `black`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The default formatter is `autopep8`. The possible formatters are:
 | Name           | Setting | Note |
 |:---------------|:--------|:-----|
 | autopep8       | `pylsp.plugins.autopep8.enabled` | |
-| black          | `pylsp.plugins.pylsp_black.enabled` | When enabling also make sure that `autopep8` and `yapf` are disabled. |
+| black          | `pylsp.plugins.black.enabled` | When enabling also make sure that `autopep8` and `yapf` are disabled. |
 | ruff           | `pylsp.plugins.ruff.formatEnabled` | Make sure to also enable `pylsp.plugins.ruff.enabled` and disable other formatters and linters. |
 | yapf           | `pylsp.plugins.yapf.enabled` | |
 


### PR DESCRIPTION
After update to python-lsp-black v2, the keys have changed to `black` everywhere, except for the docs, which I've read and then wondered why formatting does not work :D

Relates to #105 and #147